### PR TITLE
Set default QT locale to C

### DIFF
--- a/streamPick.py
+++ b/streamPick.py
@@ -15,6 +15,7 @@ from matplotlib.transforms import offset_copy
 class streamPick(QtGui.QMainWindow):
     def __init__(self, stream=None, parent=None):
         # Initialising QtGui
+        QtCore.QLocale.setDefault(QtCore.QLocale.c())
         qApp = QtGui.QApplication(sys.argv)
 
         # Init vars


### PR DESCRIPTION
Hi, I was playing with StreamPick and I noticed that it doesn't handle correctly decimal separators for non-English locales.

For instance, with the Italian locale, the decimal separator is a comma. The filter creation dialog complains about this.

This PR should fix that. 
